### PR TITLE
Use house instead of home for icon

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,7 +33,7 @@ copyright: GNU General Public License v3.0 - Leiden University Libraries
 ## Social Media
 extra:
   social:
-    - icon: fontawesome/solid/home
+    - icon: fontawesome/solid/house
       link: https://www.universiteitleiden.nl
     - icon: fontawesome/brands/github-alt
       link: https://github.com/LeidenUniversityLibrary


### PR DESCRIPTION
Newer Material for MkDocs versions use newer Fontawesome versions, in which some icons have been renamed. This caused a build failure, until I changed `home` to `house`.