### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ here = pathlib.Path(__file__).parent.resolve()
 
 # Get the long description from the README file
 long_description = (here / 'README.md').read_text(encoding='utf-8')
-VERSION = '1.0.0'
+VERSION = '1.0.1'
 
 setup(
     name="mkdocs-ubleiden-theme",


### PR DESCRIPTION
This add a minimal version of Material for MkDocs (the current latest version), which requires at least Python 3.7.
I also bumped the version number.