### PR TITLE
Implement monospace font for code blocks

### DIFF
--- a/ubleiden_theme/mkdocs_theme.yml
+++ b/ubleiden_theme/mkdocs_theme.yml
@@ -12,6 +12,6 @@ features:
 
 font:
   text: Open Sans
-  code: Ubuntu
+  code: Inconsolata
 
 logo: assets/images/favicon.png


### PR DESCRIPTION
No 100% sure about how theme works (for example: which are the settings that are read? The ones in `mkdocs.yml` as usual, or the ones in `ubleiden_theme\mkdocs_theme.yml`?)

But!

I think this does the trick: Closes #10 

Font chosen: https://fonts.google.com/specimen/Inconsolata/about

Let me know!