### PR TITLE
Add a warning about page status when `status: draft` is in metadata

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,20 @@
+---
+title: Usage
+---
+
+# Install theme
+
+Install the theme from PyPI using `pip install mkdocs-ubleiden-theme`.
+
+# Use theme in `mkdocs.yml`
+
+Set the theme of your site to `ubleiden` in `mkdocs.yml`.
+
+# Use theme features
+
+## Page draft status
+
+Add `status: draft` to the YAML metadata to have a warning added at the top
+of the page.
+Only `draft` is supported as a status; remove the status key to imply that the
+status is "not draft".

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Getting started:
+    - Usage: usage.md
     - Customization: customization.md
   - More info:
     - License: license.md

--- a/ubleiden_theme/assets/stylesheets/extra.css
+++ b/ubleiden_theme/assets/stylesheets/extra.css
@@ -16,3 +16,7 @@
   background-color: #7f88ab;
   color: #ffffff;
 }
+
+.warning-draft {
+  font-weight: bold;
+}

--- a/ubleiden_theme/main.html
+++ b/ubleiden_theme/main.html
@@ -1,1 +1,12 @@
 {% extends "basechild.html" %}
+
+{% block content %}
+    {% if page and page.meta and page.meta.status and page.meta.status == 'draft' %}
+        <p class="warning-draft"><em>This page is a draft.</em> {% if page.meta.git_revision_date_localized %}Last updated:
+            {{ page.meta.git_revision_date_localized }}
+            {% elif page.meta.revision_date %}
+            Last updated: {{ page.meta.revision_date }}
+            {% endif %}</p>
+    {% endif %}
+    {{ super() }}
+{% endblock %}


### PR DESCRIPTION
We used to have this in a theme override for the CDS Lab Homepage, but why not make it available to all?